### PR TITLE
rm Math::Units

### DIFF
--- a/most-wanted/modules.md
+++ b/most-wanted/modules.md
@@ -160,7 +160,6 @@ Internationalization and Natural Language Processing
 
 ## Numerical
 
-* Math::Units (WIP: [Unit::SI](https://github.com/holli-holzer/perl6-Unit) (Name is just temporary)
 
 
 ## Text processing


### PR DESCRIPTION
this is now implemented, albeit as [Physics::Unit](https://github.com/p6steve/raku-physics-unit.git) and [Physics::Measure]((https://github.com/p6steve/raku-physics-measure.git)

also note that the link to Units::SI is getting a 404